### PR TITLE
add diagnostics for debugging Cloudinary

### DIFF
--- a/src/api/diag/controllers/diag.js
+++ b/src/api/diag/controllers/diag.js
@@ -1,0 +1,13 @@
+module.exports = {
+  async provider(ctx) {
+    const conf = ctx?.strapi?.config?.get('plugin.upload', {}) || {};
+    ctx.body = {
+      provider: conf?.config?.provider || 'unknown',
+      envNode: process.env.NODE_ENV || 'unknown',
+      hasCloudinaryVars:
+        !!process.env.CLOUDINARY_NAME &&
+        !!process.env.CLOUDINARY_KEY &&
+        !!process.env.CLOUDINARY_SECRET,
+    };
+  },
+};

--- a/src/api/routes/diag.js
+++ b/src/api/routes/diag.js
@@ -1,0 +1,10 @@
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/_upload-provider',
+      handler: 'diag.provider',
+      config: { auth: false },
+    },
+  ],
+};


### PR DESCRIPTION
Add diagnostics for debugging Cloudinary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public GET endpoint at /_upload-provider that returns diagnostic information about the current upload provider, the runtime environment, and whether required Cloudinary environment variables are present. The response includes provider, envNode, and hasCloudinaryVars fields. This endpoint is unauthenticated to simplify troubleshooting and integration checks for clients and operations teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->